### PR TITLE
Log the SNI when ignoring a connection

### DIFF
--- a/server.go
+++ b/server.go
@@ -82,7 +82,7 @@ func (server *Server) handleConnection(clientConn net.Conn) {
 
 	backendConn, err := server.Backend.Dial(clientHello.ServerName, clientConn)
 	if err != nil {
-		log.Printf("Ignoring connection from %s because dialing backend failed: %s", clientConn.RemoteAddr(), err)
+		log.Printf("Ignoring connection from %s to %s because dialing backend failed: %s", clientConn.RemoteAddr(), clientHello.ServerName, err)
 		return
 	}
 	defer backendConn.Close()


### PR DESCRIPTION
This aids with debugging odd error messages like:

    2023/01/01 12:00:00 Ignoring connection from 192.168.1.123:34567 because dialing backend failed: dial tcp6 [2001:db8::abcd]:443: 2001:db8::abcd is not an allowed backend